### PR TITLE
Change redirect mode from follow to manual

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -105,7 +105,7 @@ async function handleRequest(request) {
   const newReq = new Request(newUrl, {
     method: request.method,
     headers: request.headers,
-    redirect: "follow",
+    redirect: "manual",
   });
   const resp = await fetch(newReq);
   if (resp.status == 401) {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -12,6 +12,7 @@ CUSTOM_DOMAIN = "libcuda.so"
 [env.dev.vars]
 MODE = "debug"
 TARGET_UPSTREAM = "https://registry-1.docker.io"
+CUSTOM_DOMAIN = "exmaple.com"
 
 [env.production]
 name = "cloudflare-docker-proxy"


### PR DESCRIPTION
fix #100 

Cloudflare worker redirection will include the auth header, which is causing the following error from the DockerHub blob upstream. 

Disable follow redirect in Cloudflare worker to fix this